### PR TITLE
Add timeout on image download and configuration + docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ Start CROC as a service on your local-machine with:
 1) `docker build -t croc-http:dev -f ./http.dockerfile .`
 2) `docker run -p 5000:5000 croc-http:dev`
 
+## Configuration
+
+You can set the following env vars to change some behaviors.
+
+- `GET_IMAGE_TIMEOUT`: int. max number of seconds to wait before triggering timeout error when downloading an image. *Default is 10s.*
+- `USE_REQUESTS_SESSION`: boolean. Toggle option for using sessions when downloading images (True) or to create a new connection on every request (False). *Default is True.* 
+
 ## Structure of this repo
 
 The core of this repo is `setup.py` and `nk_croc`. 

--- a/nk_croc/nk_croc.py
+++ b/nk_croc/nk_croc.py
@@ -19,6 +19,8 @@ from nk_croc.is_a import isa_dict
 from nk_croc.id_mapping import id_mapping_dict
 
 requests_session = requests.Session() if os.environ.get('USE_REQUESTS_SESSION') == "True" else requests
+# GET_IMAGE_TIMEOUT is max number of seconds to wait before triggering timeout error when downloading an image
+get_image_timeout = int(os.environ.get("GET_IMAGE_TIMEOUT", "10"))
 
 class Croc():
 
@@ -40,8 +42,9 @@ class Croc():
     def load_image_from_web(self, image_url):
         ''' load an image from a provided hyperlink
         '''
-        # get image
-        response = requests_session.get(image_url)
+        # get image with timout
+        # More info on using request with timeouts: http://docs.python-requests.org/en/master/user/quickstart/#timeouts
+        response = requests_session.get(image_url, timeout=get_image_timeout)
         with Image.open(io.BytesIO(response.content)) as img:
             # fill transparency if needed
             if img.mode in ('RGBA', 'LA'):


### PR DESCRIPTION
I don't know who to tag. This is hopefully the start to resolving image-consumer dying on us.

Image-consumer on occasion throws:
```logs
WARNING:kafka.coordinator.consumer:Auto offset commit failed for group image_consumer: CommitFailedError: Commit cannot be completed since the group has already 
rebalanced and assigned the partitions to another member. 
This means that the time between subsequent calls to poll() 
was longer than the configured max_poll_interval_ms, which 
typically implies that the poll loop is spending too much 
time message processing. You can address this either by 
increasing the rebalance timeout with max_poll_interval_ms, 
or by reducing the maximum size of batches returned in poll() 
with max_poll_records. 
```
My understanding of this (also confirmed with @bstarling ) is that image consumer is doing a process that takes longer than the heartbeat timeout.

Looking at datadog we see a few APMs that are > 15min long and the heartbeat timeout is set to 10min. https://app.datadoghq.com/apm/resource/croc/main.croc_predict/85ab374db4a83e4?end=1539794626292&env=prod&paused=false&start=1539189826292 

Looking deeper we see Croc returns an error after ~15min
```logs
requests.exceptions.ReadTimeout: HTTPSConnectionPool(host='www.welt.de', port=443): Read timed out. (read timeout=None)
```
The Requests docs state
> Nearly all production code should use this parameter in nearly all requests. 
http://docs.python-requests.org/en/master/user/quickstart/#timeouts

This is implementing a timeout on the only request in the repo (it downloads images). Looking at datadog, it looks like most images fully download (timeout is only concerned about time to first byte, so timeout could be shorter than the full download time) in < 2s. Errors get thrown when no response/byte comes back within ~15min. The 10s default I implemented should be very generous while still being a significant improvement.

Even if we've handled the timeout error (or the kafka error) and we're now successfully rebooting image-consumer, when it gets evicted from the consumer-group, this timeout should yield a significant improvement in prod by allowing image-consumer to move on a new image after 10s instead of 15min.